### PR TITLE
Add openai_base_url support to OpenAIEmbedder

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/openai.ts
+++ b/mem0-ts/src/oss/src/embeddings/openai.ts
@@ -2,12 +2,27 @@ import OpenAI from "openai";
 import { Embedder } from "./base";
 import { EmbeddingConfig } from "../types";
 
+// Default OpenAI API base URL
+const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
+
 export class OpenAIEmbedder implements Embedder {
   private openai: OpenAI;
   private model: string;
 
   constructor(config: EmbeddingConfig) {
-    this.openai = new OpenAI({ apiKey: config.apiKey });
+    // Get baseUrl from config, environment variables, or use default
+    const baseUrl =
+      config.openai_base_url ||
+      process.env.OPENAI_BASE_URL ||
+      process.env.OPENAI_API_BASE ||
+      DEFAULT_OPENAI_BASE_URL;
+
+    // Initialize OpenAI client with apiKey and baseUrl
+    this.openai = new OpenAI({
+      apiKey: config.apiKey,
+      baseURL: baseUrl
+    });
+
     this.model = config.model || "text-embedding-3-small";
   }
 

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -16,6 +16,7 @@ export interface EmbeddingConfig {
   apiKey?: string;
   model?: string | any;
   url?: string;
+  openai_base_url?: string;
   modelProperties?: Record<string, any>;
 }
 


### PR DESCRIPTION
This PR adds support for configuring the OpenAI base URL in the TypeScript implementation, similar to how it's done in the Python version.

## Changes

1. Added `openai_base_url` property to the `EmbeddingConfig` interface
2. Updated the `OpenAIEmbedder` constructor to use the base URL from config, environment variables, or default value
3. The priority order is: config > environment variables > default value

## Usage

```typescript
const memory = new Memory({
  embedder: {
    provider: "openai",
    config: {
      apiKey: process.env.OPENAI_API_KEY || "",
      model: "text-embedding-3-small",
      openai_base_url: "https://custom-openai-api.com/v1"  // Custom base URL
    },
  },
  // ...other config
});
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author